### PR TITLE
Extend dino with dadjoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ KaiHB:~ kai$ dino danger!
 Arguments:
 ```sh
 $ dino compliment
+$ dino dadjoke
 $ dino danger
 $ dino danger!
 $ dino dna

--- a/dino.sh
+++ b/dino.sh
@@ -49,6 +49,24 @@ elif [[ $1 = "meme" ]]; then
   else
     PUNCH="Could not detect which web browser to use."
   fi
+elif [[ $1 = "dadjoke" ]]; then
+  joke=$(curl -s https://icanhazdadjoke.com/)
+
+  # Count number of lines in the joke 
+  line_count=$(echo "$joke" | wc -l)
+
+  if [ "$line_count" == "1" ]; then
+    if [ `expr "$joke" : ".*[?].*"` -gt 0 ];
+    then 
+       STR="$(sed 's/?.*//' <<< "$joke")?"
+       PUNCH=$(sed 's/^[^?]*?//' <<< "$joke")
+    else
+      STR=$joke
+    fi
+  # NOTE(G3): Throw out multiline jokes due to formating issues
+  else
+    PUNCH="Dad Joke fail! Please try again."
+  fi
 else
   STR="Hi!"
 fi


### PR DESCRIPTION
### Description
Add a new option to dino, `dadjoke`, which curls `icanhazdadjoke.com` to retrieve a new joke each time the utility is ran.

### Possible outcomes
- If the joke contains a `?`, `sed` is used to split the joke into `STR` and `PUNCH`
- If there is no `?` found in the joke, only `STR` is populated
- If the joke contains more than one line, it is thrown out due to difficulties with formatting